### PR TITLE
Add settings.gradle required by Gradle 9.x

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-simple-project'


### PR DESCRIPTION
## Problem

Qodana JVM 2026.1 uses Gradle 9.3.0 which requires a \`settings.gradle\` file.
Without it, Gradle fails with:
\`\`\`
Directory '/data/project/gradle-simple-project' does not contain a Gradle build.
A Gradle build's root directory should contain one of the possible settings files: settings.gradle, settings.gradle.kts, settings.gradle.dcl.
\`\`\`

This caused 50+ linter e2e tests to fail in TC build StaticAnalysis_Sandbox_ActionTests #25.

## Fix

Add minimal \`settings.gradle\` with just \`rootProject.name\`.